### PR TITLE
Add Grin support

### DIFF
--- a/package
+++ b/package
@@ -206,7 +206,16 @@ downloadFunctions.pastebin = function(pack, env)
 end
 
 downloadFunctions.grin = function(package, env)
-	return env.shell.run("pastebin run VuBNx3va -u", package.download.author, "-r", package.download.repository, package.target)
+	local status
+	parallel.waitForAny(function()
+		status = env.shell.run("pastebin run VuBNx3va -e -u", package.download.author, "-r", package.download.repository, fs.combine(package.target, package.name))
+	end, function()
+		while true do
+			local e, msg = os.pullEvent("grin_install_status")
+			printInformation(msg)
+		end
+	end)
+	return status
 end
 
 function updateDatabase(pack, files)

--- a/package
+++ b/package
@@ -59,6 +59,10 @@ local downloadTypes = {
 		url = true,
 		filename = true,
 	},
+	grin = {
+		author = true,
+		repository = true,
+	},
 }
 
 local lookupFunctions = {}
@@ -199,6 +203,10 @@ end
 
 downloadFunctions.pastebin = function(pack, env)
 	return raw("http://pastebin.com/raw.php?i="..pack.download.url, fs.combine(pack.target, pack.download.filename))
+end
+
+downloadFunctions.grin = function(package, env)
+	return env.shell.run("pastebin run VuBNx3va -u", package.download.author, "-r", package.download.repository, package.target)
 end
 
 function updateDatabase(pack, files)

--- a/package
+++ b/package
@@ -140,14 +140,8 @@ local function createSingleFolder(path)
 	end
 end
 
-local downloadFunctions = {}
-
-downloadFunctions.raw = function(url, path, version)
-	if type(url) == "table" then
-		local pack = url
-		url = pack.download.url
-		path = fs.combine(pack.target, pack.download.filename)
-	end
+-- Local function to download a url raw
+local function raw(url, path, version)
 	printInformation("Fetching: "..url)
 	http.request(url)
 	while true do
@@ -177,12 +171,19 @@ downloadFunctions.raw = function(url, path, version)
 	end
 end
 
+local downloadFunctions = {}
+
+downloadFunctions.raw = function(pack)
+	-- Delegate to local raw
+	return raw(pack.download.url, fs.combine(pack.target, pack.download.filename))
+end
+
 downloadFunctions.github = function(package)
 	local contents = lookupFunctions.github(package)
 	if not contents then return nil, "content fetch failure" end
 	local localTarget = package.target or ""
 	for num, file in ipairs(contents) do
-		if not downloadFunctions.raw("https://raw.github.com/"..package.download.author.."/"..package.download.repository.."/master/"..file.path, fs.combine(localTarget, file.path), file.version) then return false end
+		if not raw("https://raw.github.com/"..package.download.author.."/"..package.download.repository.."/master/"..file.path, fs.combine(localTarget, file.path), file.version) then return false end
 	end
 	return true
 end
@@ -191,13 +192,13 @@ downloadFunctions.bitbucket = function(package)
 	local contents = lookupFunctions.bitbucket(package)
 	local localTarget = package.target or ""
 	for num, file in ipairs(contents) do
-		if not downloadFunctions.raw("https://bitbucket.org/"..package.download.author.."/"..package.download.repository.."/raw/"..package.download.branch.."/"..file.path, fs.combine(localTarget, file.path), file.version) then return false end
+		if not raw("https://bitbucket.org/"..package.download.author.."/"..package.download.repository.."/raw/"..package.download.branch.."/"..file.path, fs.combine(localTarget, file.path), file.version) then return false end
 	end
 	return true
 end
 
 downloadFunctions.pastebin = function(pack)
-	return downloadFunctions.raw("http://pastebin.com/raw.php?i="..pack.download.url, fs.combine(pack.target, pack.download.filename))
+	return raw("http://pastebin.com/raw.php?i="..pack.download.url, fs.combine(pack.target, pack.download.filename))
 end
 
 function updateDatabase(pack, files)
@@ -313,9 +314,9 @@ local Package = {
 				if file.version ~= findInstalledVersionByPath(self.repo.."/"..self.name, file.path) then
 					packAPI.removeFile(file.path)
 					if self.download.type == "github" then
-						if not downloadFunctions.raw("https://raw.github.com/"..self.download.author.."/"..self.download.repository.."/master/"..file.path, fs.combine(self.target, file.path), file.version) then return false end
+						if not raw("https://raw.github.com/"..self.download.author.."/"..self.download.repository.."/master/"..file.path, fs.combine(self.target, file.path), file.version) then return false end
 					elseif self.download.type == "bitbucket" then
-						if not downloadFunctions.raw("https://bitbucket.org/"..self.download.author.."/"..self.download.repository.."/raw/"..self.download.branch.."/"..file.path, fs.combine(self.target, file.path), file.version) then return false end
+						if not raw("https://bitbucket.org/"..self.download.author.."/"..self.download.repository.."/raw/"..self.download.branch.."/"..file.path, fs.combine(self.target, file.path), file.version) then return false end
 					end
 				end
 			end

--- a/package
+++ b/package
@@ -173,12 +173,12 @@ end
 
 local downloadFunctions = {}
 
-downloadFunctions.raw = function(pack)
+downloadFunctions.raw = function(pack, env)
 	-- Delegate to local raw
 	return raw(pack.download.url, fs.combine(pack.target, pack.download.filename))
 end
 
-downloadFunctions.github = function(package)
+downloadFunctions.github = function(package, env)
 	local contents = lookupFunctions.github(package)
 	if not contents then return nil, "content fetch failure" end
 	local localTarget = package.target or ""
@@ -188,7 +188,7 @@ downloadFunctions.github = function(package)
 	return true
 end
 
-downloadFunctions.bitbucket = function(package)
+downloadFunctions.bitbucket = function(package, env)
 	local contents = lookupFunctions.bitbucket(package)
 	local localTarget = package.target or ""
 	for num, file in ipairs(contents) do
@@ -197,7 +197,7 @@ downloadFunctions.bitbucket = function(package)
 	return true
 end
 
-downloadFunctions.pastebin = function(pack)
+downloadFunctions.pastebin = function(pack, env)
 	return raw("http://pastebin.com/raw.php?i="..pack.download.url, fs.combine(pack.target, pack.download.filename))
 end
 
@@ -263,7 +263,7 @@ setmetatable(scriptEnv, {__index = _G})
 local Package = {
 	install = function(self, env)
 		if downloadFunctions[self.download.type] then
-			if not downloadFunctions[self.download.type](self) then return false end
+			if not downloadFunctions[self.download.type](self, env) then return false end
 		end
 		if self.setup then
 			local shell = env.shell


### PR DESCRIPTION
Example package entry:

```
name = JVML
	type = grin
		author = Team-CC-Corp
		repository = JVML-JIT
	category = tool
	version = 0.52
	size = 305000
	dependencies = none
end
```

The folder extracted to is <target>/<package name>

Also, changed downloadFunctions to take an env parameter, so that the grin function could use the shell. This required moving the raw function into its own local function, with a wrapper function for the downloadFunctions table.