### PR TITLE
Fixing the name of my repo

### DIFF
--- a/repolist
+++ b/repolist
@@ -7,4 +7,4 @@ superaxander http://pastebin.com/raw.php?i=q65LuTkg
 nitrogenfingers http://pastebin.com/raw.php?i=FdwADtED
 apemanzilla https://raw.github.com/apemanzilla/repo/master/repo.txt
 coolgametube http://pastebin.com/raw.php?i=MrBgVRR3
-kd2bwz http://pastebin.com/raw.php?i=R106Q9W7
+minerobber http://pastebin.com/raw.php?i=R106Q9W7


### PR DESCRIPTION
I accidentally put it in as "kd2bwz". Now that (hopefully) my forum accounts (MineRobber___T and KD2BWZ) will become one under "MineRobber__T", I'm fixing the repo name to say "minerobber" instead of "kd2bwz".