### PR TITLE
Fix #32, capitalisation in dependency names

### DIFF
--- a/package
+++ b/package
@@ -667,6 +667,7 @@ function findDependencies(packageName, _dependencyTable)
 	if package.list[packageName] then
 		dependencyTable[packageName] = true
 		for packName in pairs(package.list[packageName].dependencies) do
+			packName = packName:lower()
 			if packName ~= "none" and not dependencyTable[packName] then
 				dependencyTable, errmsg = package.findDependencies(packName, dependencyTable)
 				if not dependencyTable then return nil, errmsg end


### PR DESCRIPTION
However packman will still crash in the for loop on line 265 if a dependency is not found.