### PR TITLE
added aaronmallen packlist to repolist

### DIFF
--- a/repolist
+++ b/repolist
@@ -16,3 +16,4 @@ admicos https://raw.githubusercontent.com/Admicos/cc-packman-repo/master/repo
 legostax https://raw.githubusercontent.com/legostax/cc-packman/master/packlist
 h4x0rz https://thefreaklord.github.io/PackManRepo/public/packlist
 wilma456 https://raw.githubusercontent.com/Wilma456/Computercraft/master/packlist
+aaronmallen https://raw.githubusercontent.com/aaronmallen/computercraft-packman-packlist/master/packlist


### PR DESCRIPTION
I have a couple of concerns about my packlist that I'd like to address and possibly repair before you merge this...

1. Does packman expect the file(s) to be there to be successful?  I have this [pastebin](http://pastebin.com/JmprtvzY) as my setup script.  If it detects that CraftOS is > 1.77 it removes my package as it isn't needed.

1. I am assuming that by not specifying a target on settings (which is a file) it will be installed as '/usr/bin/settings' and not 'usr/bin/aaronmallen/settings/settings' is this a correct assumption?

Thanks in advance for your help, and AWESOME project man!