### PR TITLE
Rename package API

### DIFF
--- a/backpack
+++ b/backpack
@@ -49,7 +49,7 @@ local currentPackage
 
 local Transaction = {
 	writeFile = function(self)
-		local path = fs.combine(package.installRoot, self.path)
+		local path = fs.combine(backpack.installRoot, self.path)
 		if fs.exists(path) then
 			local handle = io.open(path, "r")
 			if handle then
@@ -68,7 +68,7 @@ local Transaction = {
 		return true
 	end,
 	deleteFile = function(self)
-		local path = fs.combine(package.installRoot, self.path)
+		local path = fs.combine(backpack.installRoot, self.path)
 		if fs.exists(path) then
 			local handle = io.open(path, "r")
 			if handle then
@@ -81,7 +81,7 @@ local Transaction = {
 		return not fs.exists(path)
 	end,
 	makeDirectory = function(self)
-		local path = fs.combine(package.installRoot, self.path)
+		local path = fs.combine(backpack.installRoot, self.path)
 		if not fs.exists(path) then
 			printInformation("Creating directory "..path)
 			fs.makeDir(path)
@@ -89,7 +89,7 @@ local Transaction = {
 		return fs.isDir(path)
 	end,
 	removeDirectory = function(self)
-		local path = fs.combine(package.installRoot, self.path)
+		local path = fs.combine(backpack.installRoot, self.path)
 		if fs.exists(path) and fs.isDir(path) and #(fs.list(path)) == 0 then
 			printInformation("Removing directory "..path)
 			fs.delete(path)
@@ -104,7 +104,7 @@ local Transaction = {
 				--found the right entry, modify correctly now.
 				lineFound = true
 				self.contents[i] = newLine
-				updateFileInfo(package.installed[self.pack.fullName].files, self.path, self.version)
+				updateFileInfo(backpack.installed[self.pack.fullName].files, self.path, self.version)
 				break
 			end
 		end
@@ -117,9 +117,9 @@ local Transaction = {
 		for i = 1, #self.contents do
 			if self.path == string.match(self.contents[i], "^([^;]+)") then
 				table.remove(self.contents, i)
-				local entry = findFileEntry(package.installed[self.pack.fullName].files, self.path)
+				local entry = findFileEntry(backpack.installed[self.pack.fullName].files, self.path)
 				if entry then
-					table.remove(package.installed[self.pack.fullName].files, entry)
+					table.remove(backpack.installed[self.pack.fullName].files, entry)
 				end
 				break
 			end
@@ -184,10 +184,10 @@ local TransQueue = {
 		table.insert(self.transactions, newTransaction(self.pack, path, "deleteFile"))
 	end,
 	makeDir = function(self, path)
-		if string.match(path, "(.-)/[^/]+$") and not fs.exists(fs.combine(package.installRoot, string.match(path, "(.-)/[^/]+$"))) then
+		if string.match(path, "(.-)/[^/]+$") and not fs.exists(fs.combine(backpack.installRoot, string.match(path, "(.-)/[^/]+$"))) then
 			self:makeDir(string.match(path, "(.-)/[^/]+$"))
 		end
-		if not fs.exists(fs.combine(package.installRoot, path)) then
+		if not fs.exists(fs.combine(backpack.installRoot, path)) then
 			table.insert(self.transactions, newTransaction(self.pack, path, "makeDirectory"))
 		end
 	end,
@@ -211,7 +211,7 @@ local TransQueue = {
 		}
 	end,
 	finish = function(self)
-		local installedFile = fs.combine(fs.combine(package.installRoot, "/etc/.installed"), self.pack.fullName)
+		local installedFile = fs.combine(fs.combine(backpack.installRoot, "/etc/.installed"), self.pack.fullName)
 		local installedData = {}
 		if installed[self.pack.fullName] and fs.exists(installedFile) then
 			local handle = io.open(installedFile, "r")
@@ -229,12 +229,12 @@ local TransQueue = {
 		end
 
 		--ensure installed table entry exists
-		if not package.installed[self.pack.fullName] then
-			package.installed[self.pack.fullName] = {
+		if not backpack.installed[self.pack.fullName] then
+			backpack.installed[self.pack.fullName] = {
 				version = self.pack.version,
 				files = {},
 			}
-			if not package.installed[self.pack.name] then package.installed[self.pack.name] = {[self.pack.repo] = package.installed[self.pack.fullName]} end
+			if not backpack.installed[self.pack.name] then backpack.installed[self.pack.name] = {[self.pack.repo] = backpack.installed[self.pack.fullName]} end
 		end
 
 		local fileInfoUpdates = {}
@@ -270,23 +270,23 @@ local TransQueue = {
 		if self.removing and #installedData == 0 then
 			fs.delete(installedFile)
 
-			--remove entries from installed packages table if removing package.
-			package.installed[self.pack.name][self.pack.repo] = nil
+			--remove entries from installed packages table if removing backpack.
+			backpack.installed[self.pack.name][self.pack.repo] = nil
 			local othersWithName = false
-			for k, v in pairs(package.installed[self.pack.name]) do
+			for k, v in pairs(backpack.installed[self.pack.name]) do
 				if v then
 					othersWithName = true
 					break
 				end
 			end
 			if not othersWithName then
-				package.installed[self.pack.name] = nil
+				backpack.installed[self.pack.name] = nil
 			end
-			package.installed[self.pack.fullName] = nil
+			backpack.installed[self.pack.fullName] = nil
 		else
 			--write out file again, if any content exists for it.
 			table.insert(installedData, 1, tostring(self.pack.version))
-			if not fs.exists(fs.combine(fs.combine(package.installRoot, "/etc/.installed"), self.pack.repo)) then fs.makeDir(fs.combine(fs.combine(package.installRoot, "/etc/.installed"), self.pack.repo)) end
+			if not fs.exists(fs.combine(fs.combine(backpack.installRoot, "/etc/.installed"), self.pack.repo)) then fs.makeDir(fs.combine(fs.combine(backpack.installRoot, "/etc/.installed"), self.pack.repo)) end
 			local handle = io.open(installedFile, "w")
 			if handle then
 				for k, v in ipairs(installedData) do
@@ -303,7 +303,7 @@ local queueMeta = {__index = TransQueue}
 
 function newTransactionQueue(packName, removing)
 	local pack
-	if package.list[packName] and package.list[packName].version then pack = package.list[packName] else return nil, "No such package!" end
+	if backpack.list[packName] and backpack.list[packName].version then pack = backpack.list[packName] else return nil, "No such package!" end
 	local queue = {
 		pack = pack,
 		removing = removing,
@@ -528,7 +528,7 @@ downloadFunctions.grin = function(pack, env, queue, info)
 	local fullName = pack.repo.."/"..pack.name
 	local status
 	parallel.waitForAny(function()
-		status = env.shell.run("pastebin run VuBNx3va -e -u", info.author, "-r", info.repository, fs.combine(fs.combine(package.installRoot, pack.target), pack.name))
+		status = env.shell.run("pastebin run VuBNx3va -e -u", info.author, "-r", info.repository, fs.combine(fs.combine(backpack.installRoot, pack.target), pack.name))
 	end, function()
 		while true do
 			local e, msg = os.pullEvent("grin_install_status")
@@ -543,7 +543,7 @@ downloadFunctions.meta = function(pack, env, queue)
 end
 
 local function findInstalledVersionByPath(packName, path)
-	for i, file in ipairs(package.installed[packName].files) do
+	for i, file in ipairs(backpack.installed[packName].files) do
 		if file.path == path then return file.version end
 	end
 end
@@ -570,7 +570,7 @@ local Package = {
 			for match in string.gmatch(self.setup, "(%S+)") do
 				table.insert(setupArgs, match)
 			end
-			setupArgs[1] = fs.combine(fs.combine(package.installRoot, self.target), setupArgs[1])
+			setupArgs[1] = fs.combine(fs.combine(backpack.installRoot, self.target), setupArgs[1])
 			local envQueue = queue:env()
 			if not os.run({shell = env.shell, packman = envQueue, pack = envQueue, fs = new_fs}, unpack(setupArgs)) then
 				--setup script threw an error.
@@ -584,7 +584,7 @@ local Package = {
 		return true
 	end,
 	remove = function(self, env)
-		if not package.installed[self.fullName] then return false end
+		if not backpack.installed[self.fullName] then return false end
 		local queue = newTransactionQueue(self.fullName, true)
 
 		if self.cleanup then
@@ -593,15 +593,15 @@ local Package = {
 			for match in string.gmatch(self.cleanup, "(%S+)") do
 				table.insert(cleanupArgs, match)
 			end
-			cleanupArgs[1] = fs.combine(fs.combine(package.installRoot, self.target), cleanupArgs[1])
+			cleanupArgs[1] = fs.combine(fs.combine(backpack.installRoot, self.target), cleanupArgs[1])
 			local envQueue = queue:env()
 			os.run({shell = env.shell, packman = envQueue, pack = envQueue, fs = new_fs}, unpack(cleanupArgs))
 			if not queue:finish() then return false end
 		end
 
-		local fileList = package.installed[self.fullName].files
+		local fileList = backpack.installed[self.fullName].files
 		for i = #fileList, 1, -1 do
-			if fs.exists(fs.combine(package.installRoot, fileList[i].path)) and fs.isDir(fs.combine(package.installRoot, fileList[i].path)) then
+			if fs.exists(fs.combine(backpack.installRoot, fileList[i].path)) and fs.isDir(fs.combine(backpack.installRoot, fileList[i].path)) then
 				queue:removeDir(fileList[i].path)
 			else
 				queue:removeFile(fileList[i].path)
@@ -612,7 +612,7 @@ local Package = {
 		return queue:finish()
 	end,
 	upgrade = function(self, env)
-		if not package.installed[self.fullName] then return false end
+		if not backpack.installed[self.fullName] then return false end
 		local queue = newTransactionQueue(self.fullName)
 		if updateTypes[self.download.type.type] == "incremental" then
 			local updatedFiles = {}
@@ -642,9 +642,9 @@ local Package = {
 				updatedFiles[path] = true
 			end
 
-			for i, fileInfo in ipairs(package.installed[self.fullName].files) do
-				if not updatedFiles[fileInfo.path] and fileInfo.version ~= package.installed[self.fullName].version then
-					if not fs.isDir(fs.combine(package.installRoot, fileInfo.path)) or (fs.isDir(fs.combine(package.installRoot, fileInfo.path)) and #(fs.list(fs.combine(package.installRoot, fileInfo.path))) == 0) then
+			for i, fileInfo in ipairs(backpack.installed[self.fullName].files) do
+				if not updatedFiles[fileInfo.path] and fileInfo.version ~= backpack.installed[self.fullName].version then
+					if not fs.isDir(fs.combine(backpack.installRoot, fileInfo.path)) or (fs.isDir(fs.combine(backpack.installRoot, fileInfo.path)) and #(fs.list(fs.combine(backpack.installRoot, fileInfo.path))) == 0) then
 						queue:removeFile(fileInfo.path)
 					end
 				end
@@ -686,12 +686,12 @@ end
 
 function findDependencies(packageName, _dependencyTable)
 	local dependencyTable = _dependencyTable or {}
-	if package.list[packageName] then
+	if backpack.list[packageName] then
 		dependencyTable[packageName] = true
-		for packName in pairs(package.list[packageName].dependencies) do
+		for packName in pairs(backpack.list[packageName].dependencies) do
 			packName = packName:lower()
 			if packName ~= "none" and not dependencyTable[packName] then
-				dependencyTable, errmsg = package.findDependencies(packName, dependencyTable)
+				dependencyTable, errmsg = backpack.findDependencies(packName, dependencyTable)
 				if not dependencyTable then return nil, errmsg end
 			end
 		end
@@ -844,8 +844,8 @@ local function addPacks(file)
 end
 
 function load()
-	for k, v in pairs(package.list) do
-		package.list[k] = nil
+	for k, v in pairs(backpack.list) do
+		backpack.list[k] = nil
 	end
 	if fs.exists("/etc/repositories") then
 		for _, file in ipairs(fs.list("/etc/repositories")) do
@@ -853,14 +853,14 @@ function load()
 		end
 	end
 
-	for k, v in pairs(package.installed) do
-		package.installed[k] = nil
+	for k, v in pairs(backpack.installed) do
+		backpack.installed[k] = nil
 	end
-	if fs.exists(fs.combine(package.installRoot, "/etc/.installed")) and fs.isDir(fs.combine(package.installRoot, "/etc/.installed")) then
-		for _, repo in ipairs(fs.list(fs.combine(package.installRoot, "/etc/.installed"))) do
-			for _, file in ipairs(fs.list(fs.combine(fs.combine(package.installRoot, "/etc/.installed"), repo))) do
+	if fs.exists(fs.combine(backpack.installRoot, "/etc/.installed")) and fs.isDir(fs.combine(backpack.installRoot, "/etc/.installed")) then
+		for _, repo in ipairs(fs.list(fs.combine(backpack.installRoot, "/etc/.installed"))) do
+			for _, file in ipairs(fs.list(fs.combine(fs.combine(backpack.installRoot, "/etc/.installed"), repo))) do
 				local name = repo.."/"..file
-				local handle = io.open(fs.combine(fs.combine(fs.combine(package.installRoot, "/etc/.installed"), repo), file), "r")
+				local handle = io.open(fs.combine(fs.combine(fs.combine(backpack.installRoot, "/etc/.installed"), repo), file), "r")
 				if handle then
 					installed[name] = {files = {}}
 					local packVersion
@@ -894,7 +894,7 @@ function load()
 		new_fs[k] = nil
 	end
 	do
-		local root = package.installRoot
+		local root = backpack.installRoot
 		--override fs api to use installRoot, recreated when loading to accomodate installRoot changes.
 		local function fsWrap(name,f,n)
 			return function(...)

--- a/packlist
+++ b/packlist
@@ -4,8 +4,8 @@ name = packman
 		filename = packman
 	setup = packman fetch
 	category = utility
-	dependencies = main/package
-	version = 0.4.1
+	dependencies = main/backpack
+	version = 0.5.0
 	size = 17227
 end
 
@@ -21,13 +21,21 @@ name = easy-shell
 	size = 1626
 end
 
-name = package
+name = backpack
 	type = raw
-		url = https://raw.githubusercontent.com/lyqyd/cc-packman/master/package
-		filename = package
+		url = https://raw.githubusercontent.com/lyqyd/cc-packman/master/backpack
+		filename = backpack
 	category = utility api
 	target = /usr/apis
 	dependencies = none
-	version = 0.2
-	size = 28393
+	version = 0.3.0
+	size = 27526
+end
+
+name = package
+	type = meta
+	category = deprecated
+	dependencies = main/backpack
+	version = 0.3.0
+	size = 0
 end

--- a/packman
+++ b/packman
@@ -1,6 +1,6 @@
 local unpack = unpack or table.unpack
 
-os.unloadAPI("package")
+os.unloadAPI("backpack")
 
 local args = {...}
 
@@ -114,14 +114,14 @@ local function getUserInput(default)
 end
 
 local function loadPackageAPI()
-	if not package then if shell.resolveProgram("package") then os.loadAPI(shell.resolveProgram("package")) elseif fs.exists("usr/apis/package") then os.loadAPI("usr/apis/package") elseif not (fetch or mode == "bootstrap") then error("Could not load package API!") end end
+	if not backpack then if shell.resolveProgram("backpack") then os.loadAPI(shell.resolveProgram("backpack")) elseif fs.exists("usr/apis/backpack") then os.loadAPI("usr/apis/backpack") elseif not (fetch or mode == "bootstrap") then error("Could not load backpack API!") end end
 
-	if package then
+	if backpack then
 		resetScreen()
 		io.write("Loading database...\n")
-		package.installRoot = target
+		backpack.installRoot = target
 
-		local co = coroutine.create(package.load)
+		local co = coroutine.create(backpack.load)
 		local event, filter, passback = {}
 		while true do
 			if (filter and (filter == event[1] or event[1] == "terminate")) or not filter then
@@ -154,8 +154,8 @@ local categorySorted = {}
 
 if fetch then
 	local queue
-	if package then
-		queue = package.newTransactionQueue("main/package")
+	if backpack then
+		queue = backpack.newTransactionQueue("main/backpack")
 	end
 	io.write("Fetching Repository List\n")
 	local repolistContent
@@ -217,14 +217,14 @@ if fetch then
 	fetch = false
 
 	if #mode > 0 then
-		--reload package API.
-		os.unloadAPI("package")
+		--reload backpack API.
+		os.unloadAPI("backpack")
 		loadPackageAPI()
 	end
 end
 
-if #mode > 0 and package then
-	for n, v in pairs(package.list) do
+if #mode > 0 and backpack then
+	for n, v in pairs(backpack.list) do
 		if v.category then
 			for category in pairs(v.category) do
 				if not categoryList[category] then
@@ -240,11 +240,11 @@ if #mode > 0 and package then
 
 	local badPackages = {}
 	--flesh out dependencies
-	for pName, pData in pairs(package.list) do
+	for pName, pData in pairs(backpack.list) do
 		if pData.dependencies then
-			dependencies, errmsg = package.findDependencies(pName, {})
+			dependencies, errmsg = backpack.findDependencies(pName, {})
 			if not dependencies then
-				--if dependencies could not be resolved, remove the package.
+				--if dependencies could not be resolved, remove the backpack.
 				printWarning("Could not resolve dependency on "..errmsg.." in package "..pName)
 				table.insert(badPackages, pName)
 			else
@@ -254,10 +254,10 @@ if #mode > 0 and package then
 	end
 	--actual package removal and short-name lookup cleanup.
 	for _, pack in pairs(badPackages) do
-		local entry = package.list[pack]
+		local entry = backpack.list[pack]
 		local name = entry.name
 		local others, key = false
-		for k, v in pairs(package.list[name]) do
+		for k, v in pairs(backpack.list[name]) do
 			if v == entry then
 				key = k
 			else
@@ -265,26 +265,26 @@ if #mode > 0 and package then
 			end
 		end
 		if others then
-			package.list[name][key] = nil
+			backpack.list[name][key] = nil
 		else
-			package.list[name] = nil
+			backpack.list[name] = nil
 		end
-		package.list[pack] = nil
+		backpack.list[pack] = nil
 	end
 end
 
 local function lookupPackage(name, installedOnly)
-	if package.list[name] and not package.list[name].dependencies then
+	if backpack.list[name] and not backpack.list[name].dependencies then
 		local options = {}
-		if installedOnly and package.installed[name] then
-			for name, pack in pairs(package.installed[name]) do
+		if installedOnly and backpack.installed[name] then
+			for name, pack in pairs(backpack.installed[name]) do
 				table.insert(options, name)
 			end
 		elseif installedOnly then
 			--using installedOnly, but no packages of that name are installed.
 			return false
 		else
-			for name, pack in pairs(package.list[name]) do
+			for name, pack in pairs(backpack.list[name]) do
 				table.insert(options, name)
 			end
 		end
@@ -304,7 +304,7 @@ local function lookupPackage(name, installedOnly)
 		else
 			return false
 		end
-	elseif package.list[name] then
+	elseif backpack.list[name] then
 		--since it must have a dependencies table, the name is already fully unique.
 		return name
 	else
@@ -313,7 +313,7 @@ local function lookupPackage(name, installedOnly)
 end
 
 local function raw_package_operation(name, funcName)
-	local pack = package.list[name]
+	local pack = backpack.list[name]
 	if not pack then return nil, "No such package" end
 	local co = coroutine.create(function() return pack[funcName](pack, getfenv()) end)
 	local event, filter, passback = {}
@@ -353,21 +353,21 @@ local function upgrade(name)
 end
 
 if mode == "bootstrap" then
-	--initial setup, results in main/packman and main/package packages being installed
-	if not package or package.list["main/packman"] == nil then
-		--grab the package API, since we have no transaction queue yet.
-		io.write("Updating package API\n")
-		remoteHandle = http.get("https://raw.githubusercontent.com/lyqyd/cc-packman/master/package")
+	--initial setup, results in main/packman and main/backpack packages being installed
+	if not backpack or backpack.list["main/packman"] == nil then
+		--grab the backpack API, since we have no transaction queue yet.
+		io.write("Updating Backpack API\n")
+		remoteHandle = http.get("https://raw.githubusercontent.com/lyqyd/cc-packman/master/backpack")
 		local apiContents = ""
 		if remoteHandle then
 			if not fs.exists("/usr/apis") then fs.makeDir("/usr/apis") end
-			local fileHandle = io.open("/usr/apis/package", "w")
+			local fileHandle = io.open("/usr/apis/backpack", "w")
 			if fileHandle then
 				apiContents = remoteHandle.readAll()
 				fileHandle:write(apiContents)
 				fileHandle:close()
 			else
-				printWarning("Could not write file /usr/apis/package")
+				printWarning("Could not write file /usr/apis/backpack")
 			end
 			remoteHandle.close()
 		else
@@ -392,25 +392,25 @@ if mode == "bootstrap" then
 			printWarning("Could not retrieve remote file.")
 		end
 
-		os.unloadAPI("package")
+		os.unloadAPI("backpack")
 		loadPackageAPI()
-		if not package then printError("Package API required for bootstrap!") end
+		if not backpack then printError("Backpack API required for bootstrap!") end
 
 		--re-do the file writes for the files above so they end up in the package file list.
-		local queue = package.newTransactionQueue("main/package")
+		local queue = backpack.newTransactionQueue("main/backpack")
 		queue:makeDir("/usr")
 		queue:makeDir("/usr/apis")
-		queue:addFile("/usr/apis/package", apiContents)
+		queue:addFile("/usr/apis/backpack", apiContents)
 		queue:makeDir("/etc")
 		queue:makeDir("/etc/repositories")
 		queue:addFile("/etc/repositories/main", packlistContents)
 		queue:finish()
 	end
 
-	package.list["main/packman"]:install(getfenv())
+	backpack.list["main/packman"]:install(getfenv())
 
-	--reload package API.
-	os.unloadAPI("package")
+	--reload backpack API.
+	os.unloadAPI("backpack")
 	loadPackageAPI()
 elseif mode == "install" then
 	if #operation.arguments >= 1 then
@@ -420,8 +420,8 @@ elseif mode == "install" then
 			if not result then
 				printWarning("Could not install package "..packageName..".")
 			else
-				for k,v in pairs(package.list[result].dependencies) do
-					if not package.installed[k] then
+				for k,v in pairs(backpack.list[result].dependencies) do
+					if not backpack.installed[k] then
 						installList[k] = true
 					else
 						if k == result then
@@ -464,12 +464,12 @@ elseif mode == "update" then
 			end
 		end
 	else
-		for k, v in pairs(package.installed) do
+		for k, v in pairs(backpack.installed) do
 			if v.files then
 				--filters out the disambiguation entries.
 				table.insert(updateList, k)
-				for name, info in pairs(package.list[k].dependencies) do
-					if not package.installed[name] then
+				for name, info in pairs(backpack.list[k].dependencies) do
+					if not backpack.installed[name] then
 						installList[name] = true
 					end
 				end
@@ -482,7 +482,7 @@ elseif mode == "update" then
 	end
 	if not forced then
 		for i = #updateList, 1, -1 do
-			if package.installed[updateList[i]].version == package.list[updateList[i]].version then
+			if backpack.installed[updateList[i]].version == backpack.list[updateList[i]].version then
 				table.remove(updateList, i)
 			end
 		end
@@ -535,10 +535,10 @@ elseif mode == "remove" then
 		end
 		dependeesList = {}
 		--find packages which depend on the packages we are removing.
-		for pName, pData in pairs(package.installed) do
+		for pName, pData in pairs(backpack.installed) do
 			if pData.version then
 				if not packageList[pName] then
-					for dName in pairs(package.list[pName].dependencies) do
+					for dName in pairs(backpack.list[pName].dependencies) do
 						for _, packName in pairs(packageList) do
 							if packName == dName then
 								dependeesList[pName] = true
@@ -594,7 +594,7 @@ elseif mode == "list" then
 		--list with matching.
 		match = operation.arguments[1]
 	end
-	for name, info in pairs(package.installed) do
+	for name, info in pairs(backpack.installed) do
 		if info.version then
 			if string.match(name, match) then
 				io.write(name.." "..info.version.."\n")
@@ -608,10 +608,10 @@ elseif mode == "search" then
 		--search using a match
 		match = operation.arguments[1]
 	end
-	for name, info in pairs(package.list) do
+	for name, info in pairs(backpack.list) do
 		if info.version then
 			if string.match(name, match) then
-				io.write((package.installed[name] and "I " or "A " )..name.." "..info.version.."\n")
+				io.write((backpack.installed[name] and "I " or "A " )..name.." "..info.version.."\n")
 			end
 		end
 	end


### PR DESCRIPTION
This PR contains changes to the package API (now named backpack, for **pack**man **back**end), as well as changes in packman and the main package list to support the renaming of the API. This is to improve compatibility with the recent addition of lua's package API to ComputerCraft in CraftOS 1.8.