### PR TITLE
Update repolist entry for admicos

### DIFF
--- a/repolist
+++ b/repolist
@@ -9,7 +9,7 @@ minerobber https://khuxkm.tilde.team/computercraft/packages.txt
 mrobsidy https://raw.githubusercontent.com/MrObsidy/technical-data-inf/master/packlist
 leoverto https://raw.github.com/LeoVerto/cc-programs/master/packlist
 ale32bit https://raw.github.com/Ale32bit/cc-packman/master/packlist
-admicos https://raw.githubusercontent.com/Admicos/cc-packman-repo/master/repo
+admicos https://git.ebc.li/archive/cc-packman-repo/raw/branch/master/repo
 legostax https://raw.githubusercontent.com/legostax/cc-packman/master/packlist
 h4x0rz https://magnificentpako.github.io/PackManRepo/public/packlist
 jakobdev https://gitlab.com/JakobDev/Computercraft/raw/master/packlist.txt


### PR DESCRIPTION
The `admicos` repository has been moved from https://github.com/Admicos/cc-packman-repo to https://git.ebc.li/archive/cc-packman-repo/.