### PR TITLE
Fix backpack queue.finish called without self reference

### DIFF
--- a/backpack
+++ b/backpack
@@ -692,7 +692,7 @@ local Package = {
 				end
 			end
 
-			return queue.finish()
+			return queue:finish()
 		elseif updateTypes[self.download.type.type] == "overwrite" then
 			if not downloadFunctions[self.download.type.type](self, env, queue, self.download.type, self.target) then return false end
 			return queue:finish()
@@ -753,7 +753,7 @@ local Package = {
 				end
 			end
 
-			return queue.finish()
+			return queue:finish()
 		elseif updateTypes[self.download.help.type] == "overwrite" then
 			if not downloadFunctions[self.download.help.type](self, env, queue, self.download.help, fs.combine("/etc/help", self.fullName)) then return false end
 			return queue:finish()

--- a/packlist
+++ b/packlist
@@ -28,8 +28,8 @@ name = backpack
 	category = utility api
 	target = /usr/apis
 	dependencies = none
-	version = 0.3.3
-	size = 34155
+	version = 0.3.4
+	size = 33107
 end
 
 name = package


### PR DESCRIPTION
The `finish` method was called without `self` reference on multiple places in the backpack, preventing it from finalizing update/removal in some cases
Changed `queue.finish()` to `queue:finish()` where applicable to fix that.